### PR TITLE
fix: correct WaitForConfirms timeout handling in ConfirmSessionOrThrow

### DIFF
--- a/src/dajet-runtime/adapters/rabbitmq/Producer.cs
+++ b/src/dajet-runtime/adapters/rabbitmq/Producer.cs
@@ -630,6 +630,8 @@ namespace DaJet.Runtime.RabbitMQ
             {
                 bool acked = _channel.WaitForConfirms(PublisherConfirmsTimeout, out bool timedout);
 
+                ThrowIfSessionIsBroken(); // STATE_BROKEN
+
                 if (timedout)
                 {
                     throw new OperationCanceledException(ERROR_WAIT_FOR_CONFIRMS);
@@ -640,7 +642,6 @@ namespace DaJet.Runtime.RabbitMQ
                     throw new OperationCanceledException(ERROR_PUBLISHER_CONFIRMS);
                 }
 
-                ThrowIfSessionIsBroken(); // STATE_BROKEN
             }
             else
             {

--- a/src/dajet-runtime/adapters/rabbitmq/Producer.cs
+++ b/src/dajet-runtime/adapters/rabbitmq/Producer.cs
@@ -628,18 +628,19 @@ namespace DaJet.Runtime.RabbitMQ
         {
             if (Interlocked.CompareExchange(ref _state, STATE_ACTIVE, STATE_ACTIVE) == STATE_ACTIVE)
             {
-                if (_channel.WaitForConfirms(PublisherConfirmsTimeout, out bool timedout))
-                {
-                    ThrowIfSessionIsBroken(); // STATE_BROKEN
-                }
-                else if (timedout)
+                bool acked = _channel.WaitForConfirms(PublisherConfirmsTimeout, out bool timedout);
+
+                if (timedout)
                 {
                     throw new OperationCanceledException(ERROR_WAIT_FOR_CONFIRMS);
                 }
-                else
+
+                if (!acked)
                 {
                     throw new OperationCanceledException(ERROR_PUBLISHER_CONFIRMS);
                 }
+
+                ThrowIfSessionIsBroken(); // STATE_BROKEN
             }
             else
             {


### PR DESCRIPTION
Fixes: #30 

### Причина
`ConfirmSessionOrThrow()` использует `if (WaitForConfirms(...)) ... else if (timedout) ...`.
`WaitForConfirms` может вернуть `true` одновременно с `timedout = true`, если broker не 
прислал ни ack, ни nack за время таймаута. Ветка `timedout` в этом случае не выполняется, 
и сообщение ошибочно считается доставленным.

### Исправление
Проверка `timedout` вынесена в отдельное независимое условие.

### Тестирование
Собран релиз, задеплоен на продуктивной среде на нестабильном канале связи. До фикса 
баг воспроизводился (совпадение с 60-секундным `PublisherConfirmsTimeout`), после — 
потерь сообщений не зафиксировано.